### PR TITLE
remove context from tracking methods

### DIFF
--- a/demo/src/main/java/com/pixable/trackingwrap/demo/DemoApplication.java
+++ b/demo/src/main/java/com/pixable/trackingwrap/demo/DemoApplication.java
@@ -28,7 +28,7 @@ public class DemoApplication extends Application {
                 .addPlatform(new GoogleAnalyticsPlatform(Constants.PlatformIds.GOOGLE_ANALYTICS.name(), new GoogleAnalyticsPlatform.Config("ga-app-key", gaDimensionsMapping, gaMetricsMapping)))
                 .addPlatform(new FacebookPlatform(Constants.PlatformIds.FACEBOOK.name(), new FacebookPlatform.Config("fb-app-key", fbEventsMapping, fbParametersMapping)))
                 .addTrace(new LogcatTraceProxy(Constants.Traces.LOGCAT.name()))
-                .addTrace(new ToastTraceProxy(Constants.Traces.TOASTS.name()))
+                .addTrace(new ToastTraceProxy(this, Constants.Traces.TOASTS.name()))
                 .build();
         Pixalytics.createInstance(configuration).onApplicationCreate(this);
     }

--- a/demo/src/main/java/com/pixable/trackingwrap/demo/MainActivity.java
+++ b/demo/src/main/java/com/pixable/trackingwrap/demo/MainActivity.java
@@ -23,12 +23,13 @@ public class MainActivity extends ActionBarActivity {
         commonProperties.put("Common Key", "Value2");
     }
 
-    private TraceProxy toastTrace = new ToastTraceProxy(Constants.Traces.TOASTS.name());
+    private TraceProxy toastTrace;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        toastTrace = new ToastTraceProxy(this, Constants.Traces.TOASTS.name());
         trackScreen();
     }
 
@@ -40,7 +41,7 @@ public class MainActivity extends ActionBarActivity {
         Pixalytics.get().onSessionStart(this, Constants.PlatformIds.FLURRY.name());
 
         //Add some commonProperties
-        Pixalytics.get().addCommonProperties(this, commonProperties, Constants.PlatformIds.MIXPANEL.name(), Constants.PlatformIds.GOOGLE_ANALYTICS.name());
+        Pixalytics.get().addCommonProperties(commonProperties, Constants.PlatformIds.MIXPANEL.name(), Constants.PlatformIds.GOOGLE_ANALYTICS.name());
     }
 
     @Override
@@ -50,11 +51,11 @@ public class MainActivity extends ActionBarActivity {
     }
 
     public void onFlurryClick(View view) {
-        Pixalytics.get().trackEvent(this, new Event.Builder().name("Foo").build(), Constants.PlatformIds.FLURRY.name());
+        Pixalytics.get().trackEvent(new Event.Builder().name("Foo").build(), Constants.PlatformIds.FLURRY.name());
     }
 
     public void onMixpanelClick(View view) {
-        Pixalytics.get().trackEvent(this,
+        Pixalytics.get().trackEvent(
                 new Event.Builder().name("Foo")
                         .property("Key1", "Value1")
                         .build(),
@@ -62,7 +63,7 @@ public class MainActivity extends ActionBarActivity {
     }
 
     public void onGoogleAnalyticsClick(View view) {
-        Pixalytics.get().trackEvent(this,
+        Pixalytics.get().trackEvent(
                 new Event.Builder().name("Foo")
                         .property("Key1", "Value1")
                         .property("Key2", "Value2")
@@ -72,7 +73,7 @@ public class MainActivity extends ActionBarActivity {
     }
 
     public void onFacebookClick(View view) {
-        Pixalytics.get().trackEvent(this,
+        Pixalytics.get().trackEvent(
                 new Event.Builder().name("Foo")
                         .property("Key1", "Value1")
                         .property("Key2", "Value2")
@@ -82,7 +83,7 @@ public class MainActivity extends ActionBarActivity {
     }
 
     public void onAllPlatformsClick(View view) {
-        Pixalytics.get().trackEvent(this,
+        Pixalytics.get().trackEvent(
                 new Event.Builder().name("Bar")
                         .property("Key1", "Value1")
                         .property("Key2", "Value2")

--- a/pixalytics-core/build.gradle
+++ b/pixalytics-core/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 ext {
     libraryArtifact = 'pixalytics-core'
-    libraryVersion = '0.6.0'
+    libraryVersion = '0.7.0'
     libraryDescription = 'Core of the library, that provides the client API'
 }
 apply from: 'https://raw.githubusercontent.com/androidsx/jcenter-publish/master/bintray_publish.gradle'

--- a/pixalytics-core/src/main/java/com/pixable/pixalytics/core/Pixalytics.java
+++ b/pixalytics-core/src/main/java/com/pixable/pixalytics/core/Pixalytics.java
@@ -68,8 +68,7 @@ public class Pixalytics {
      */
     public void onApplicationCreate(Context context) {
         for (TraceProxy trace : configuration.getTraces()) {
-            trace.traceMessage(context,
-                    TraceProxy.Level.DEBUG,
+            trace.traceMessage(TraceProxy.Level.DEBUG,
                     "On application create",
                     Collections.<String, Object>emptyMap(),
                     configuration.getPlatforms());
@@ -96,8 +95,7 @@ public class Pixalytics {
         final Set<Platform> platforms = checkAndGetPlatformsFromIds(platformIds);
 
         for (TraceProxy trace : configuration.getTraces()) {
-            trace.traceMessage(context,
-                    TraceProxy.Level.DEBUG,
+            trace.traceMessage(TraceProxy.Level.DEBUG,
                     "Session start",
                     Collections.<String, Object>emptyMap(),
                     platforms);
@@ -128,22 +126,19 @@ public class Pixalytics {
      * concept, such as Mixpanel's super-properties. For others, this is managed by an
      * external mechanism or not supported.
      *
-     * @param context activity context
      * @param name name of the property to add
      * @param value value of the property to add. If null, the property will be cleared
      * @param platformIds platforms to which this event is to be sent. At least one platform must
      *                    be provided
      */
-    public void addCommonProperty(Context context, final String name, final Object value,
-                                  String... platformIds) {
+    public void addCommonProperty(final String name, final Object value, String... platformIds) {
         if (value == null) {
             clearCommonProperty(name, platformIds);
         } else {
             final Set<Platform> platforms = checkAndGetPlatformsFromIds(platformIds);
 
             for (TraceProxy trace : configuration.getTraces()) {
-                trace.traceMessage(context,
-                        TraceProxy.Level.DEBUG,
+                trace.traceMessage(TraceProxy.Level.DEBUG,
                         "Register common property",
                         new HashMap<String, Object>() {{
                             put(name, value);
@@ -160,10 +155,9 @@ public class Pixalytics {
     /**
      * @see #addCommonProperty
      */
-    public void addCommonProperties(Context context, Map<String, Object> commonProperties,
-                                    String... platformIds) {
+    public void addCommonProperties(Map<String, Object> commonProperties, String... platformIds) {
         for (Map.Entry<String, Object> entry : commonProperties.entrySet()) {
-            addCommonProperty(context, entry.getKey(), entry.getValue(), platformIds);
+            addCommonProperty(entry.getKey(), entry.getValue(), platformIds);
         }
     }
 
@@ -204,13 +198,12 @@ public class Pixalytics {
      * @throws java.lang.UnsupportedOperationException if user properties are not supported by
      *                                                 this platform
      */
-    public void addUserProperty(Context context, String name, Object value, String... platformIds) {
+    public void addUserProperty(String name, Object value, String... platformIds) {
         final Set<Platform> platforms = checkAndGetPlatformsFromIds(platformIds);
 
         // Trace
         for (TraceProxy trace : configuration.getTraces()) {
-            trace.traceMessage(context,
-                    TraceProxy.Level.DEBUG,
+            trace.traceMessage(TraceProxy.Level.DEBUG,
                     "Register user property",
                     Collections.singletonMap(name, value),
                     platforms);
@@ -225,12 +218,11 @@ public class Pixalytics {
     /**
      * Tracks the provided event in the provided platforms.
      *
-     * @param context activity context
      * @param event event to be tracked
      * @param platformIds platforms to which this event is to be sent. At least one platform must
      *                    be provided
      */
-    public void trackEvent(Context context, Event event, String... platformIds) {
+    public void trackEvent(Event event, String... platformIds) {
         final Set<Platform> platforms = checkAndGetPlatformsFromIds(platformIds);
 
         // Let's work on a copy to make sure tracers or platforms don't fiddle with the properties
@@ -238,8 +230,7 @@ public class Pixalytics {
 
         // Trace
         for (TraceProxy trace : configuration.getTraces()) {
-            trace.traceMessage(context,
-                    TraceProxy.Level.INFO,
+            trace.traceMessage(TraceProxy.Level.INFO,
                     eventCopy.getName(),
                     eventCopy.getProperties(),
                     platforms);
@@ -254,7 +245,6 @@ public class Pixalytics {
     /**
      * Tracks a screen transition in the provided platforms.
      *
-     * @param context activity context
      * @param screen screen to be tracked
      * @param platformIds platforms to which this event is to be sent. At least one platform must
      *                    be provided
@@ -263,8 +253,7 @@ public class Pixalytics {
         final Set<Platform> platforms = checkAndGetPlatformsFromIds(platformIds);
 
         for (TraceProxy trace : configuration.getTraces()) {
-            trace.traceMessage(context,
-                    TraceProxy.Level.DEBUG,
+            trace.traceMessage(TraceProxy.Level.DEBUG,
                     "Screen " + screen.getName(),
                     screen.getProperties(),
                     platforms);
@@ -278,22 +267,20 @@ public class Pixalytics {
     /**
      * Tracks a social interaction
      *
-     * @param context activity context
      * @param network network where social interaction happened
      * @param action action happening in social interaction
      * @param target target associated to social interaction
      * @param platformIds platforms to which this event is to be sent. At least one platform must
      *                    be provided
      */
-    public void trackSocial(Context context, String network, String action, String target, String... platformIds) {
+    public void trackSocial(String network, String action, String target, String... platformIds) {
         final Set<Platform> platforms = checkAndGetPlatformsFromIds(platformIds);
         Map<String, Object> properties = new HashMap<>();
         properties.put("network", network);
         properties.put("action", action);
         properties.put("target", target);
         for (TraceProxy trace : configuration.getTraces()) {
-            trace.traceMessage(context,
-                    TraceProxy.Level.INFO,
+            trace.traceMessage(TraceProxy.Level.INFO,
                     "Social Interaction",
                     properties,
                     platforms);
@@ -307,18 +294,16 @@ public class Pixalytics {
     /**
      * Tracks revenue generated after the purchase of a product.
      *
-     * @param context activity context
      * @param product product that was purchased
      * @param revenue revenue generated by this purchase
      * @param platformIds platforms to which this event is to be sent. At least one platform must
      *                    be provided
      */
-    public void trackRevenue(Context context, String product, double revenue, String... platformIds) {
+    public void trackRevenue(String product, double revenue, String... platformIds) {
         final Set<Platform> platforms = checkAndGetPlatformsFromIds(platformIds);
 
         for (TraceProxy trace : configuration.getTraces()) {
-            trace.traceMessage(context,
-                    TraceProxy.Level.DEBUG,
+            trace.traceMessage(TraceProxy.Level.DEBUG,
                     "Purchased " + product,
                     Collections.singletonMap("Revenue", (Object) ("$" + revenue)),
                     platforms);

--- a/pixalytics-core/src/main/java/com/pixable/pixalytics/core/trace/LogcatTraceProxy.java
+++ b/pixalytics-core/src/main/java/com/pixable/pixalytics/core/trace/LogcatTraceProxy.java
@@ -1,6 +1,5 @@
 package com.pixable.pixalytics.core.trace;
 
-import android.content.Context;
 import android.util.Log;
 
 import com.pixable.pixalytics.core.platform.Platform;
@@ -23,7 +22,7 @@ public class LogcatTraceProxy implements TraceProxy {
     }
 
     @Override
-    public void traceMessage(Context context, Level level, String messageTitle, Map<String, Object> properties, Collection<Platform> platforms) {
+    public void traceMessage(Level level, String messageTitle, Map<String, Object> properties, Collection<Platform> platforms) {
         final String finalMessage = messageTitle + " (" + properties + ") to " + platforms.toString();
         switch (level) {
             case DEBUG:

--- a/pixalytics-core/src/main/java/com/pixable/pixalytics/core/trace/ToastTraceProxy.java
+++ b/pixalytics-core/src/main/java/com/pixable/pixalytics/core/trace/ToastTraceProxy.java
@@ -38,6 +38,10 @@ public class ToastTraceProxy implements TraceProxy {
      */
     final Map<Level, Integer> backgroundColorMap = new HashMap<>();
 
+    /**
+     * @param context any type of context. Only the application context will be accessed and retained
+     * @param id your unique identifier for this trace proxy
+     */
     public ToastTraceProxy(Context context, String id) {
         this.applicationContext = context.getApplicationContext();
         this.id = id;

--- a/pixalytics-core/src/main/java/com/pixable/pixalytics/core/trace/TraceProxy.java
+++ b/pixalytics-core/src/main/java/com/pixable/pixalytics/core/trace/TraceProxy.java
@@ -1,7 +1,5 @@
 package com.pixable.pixalytics.core.trace;
 
-import android.content.Context;
-
 import com.pixable.pixalytics.core.platform.Platform;
 
 import java.util.Collection;
@@ -13,11 +11,7 @@ public interface TraceProxy {
 
     String getId();
 
-    /**
-     * Must be run in the UI thread.
-     */
-    void traceMessage(Context context,
-                      Level level,
+    void traceMessage(Level level,
                       String messageTitle,
                       Map<String, Object> properties, Collection<Platform> platforms);
 }


### PR DESCRIPTION
Add context to `ToastTraceProxy`constructor and remove it from several methods on `Pixalytics` as it is only needed for Toasts
