### PR TITLE
Make Event#property take Object

### DIFF
--- a/pixalytics-core/build.gradle
+++ b/pixalytics-core/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 ext {
     libraryArtifact = 'pixalytics-core'
-    libraryVersion = '0.7.0'
+    libraryVersion = '0.7.1'
     libraryDescription = 'Core of the library, that provides the client API'
 }
 apply from: 'https://raw.githubusercontent.com/androidsx/jcenter-publish/master/bintray_publish.gradle'

--- a/pixalytics-core/src/main/java/com/pixable/pixalytics/core/Event.java
+++ b/pixalytics-core/src/main/java/com/pixable/pixalytics/core/Event.java
@@ -41,7 +41,7 @@ public class Event extends KeyValueMap {
         /**
          * Adds a property. Add as many properties (key-value pairs) as you wish.
          */
-        public Builder property(String name, String value) {
+        public Builder property(String name, Object value) {
             properties.put(name, value);
             return this;
         }


### PR DESCRIPTION
Given that the properties is a map from String to Object, there's no need to restrict values to be Strings